### PR TITLE
FAI-1929 Recruit - Remove and replace EmployerInfo view in mongoDb

### DIFF
--- a/src/SFA.DAS.EmployerAccounts.Api.UnitTests/Controllers/LegalEntitiesControllerTests/LegalEntitiesControllerTests.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api.UnitTests/Controllers/LegalEntitiesControllerTests/LegalEntitiesControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.EmployerAccounts.Api.Controllers;
@@ -11,14 +12,16 @@ namespace SFA.DAS.EmployerAccounts.Api.UnitTests.Controllers.LegalEntitiesContro
         protected LegalEntitiesController Controller;
         protected Mock<IMediator> Mediator;
         protected Mock<IUrlHelper> UrlTestHelper;
+        protected Mock<ILogger<LegalEntitiesController>> Logger;
 
         [SetUp]
         public void Arrange()
         {
             Mediator = new Mock<IMediator>();
             UrlTestHelper = new Mock<IUrlHelper>();
+            Logger = new Mock<ILogger<LegalEntitiesController>>();
 
-            Controller = new LegalEntitiesController(Mediator.Object);
+            Controller = new LegalEntitiesController(Mediator.Object, Logger.Object);
 
             Controller.Url = UrlTestHelper.Object;
 

--- a/src/SFA.DAS.EmployerAccounts.Api.UnitTests/Controllers/LegalEntitiesControllerTests/WhenGettingAllByAccountId.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api.UnitTests/Controllers/LegalEntitiesControllerTests/WhenGettingAllByAccountId.cs
@@ -1,0 +1,120 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EmployerAccounts.Api.Controllers;
+using SFA.DAS.EmployerAccounts.Api.Responses;
+using SFA.DAS.EmployerAccounts.Models;
+using SFA.DAS.EmployerAccounts.Models.Account;
+using SFA.DAS.EmployerAccounts.Queries.GetAllAccountLegalEntitiesByHashedAccountId;
+using SFA.DAS.Testing.AutoFixture;
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.EmployerAccounts.Api.UnitTests.Controllers.LegalEntitiesControllerTests
+{
+    [TestFixture]
+    public class WhenGettingAllByAccountId
+    {
+        [Test, RecursiveMoqAutoData]
+        public async Task GetAllByAccountId_ReturnsOk_WhenLegalEntitiesExist(
+        long accountId,
+        int pageNumber,
+        int pageSize,
+        string sortColumn,
+        bool isAscending,
+        GetAllAccountLegalEntitiesByHashedAccountIdQueryResult mockResponse,
+        [Frozen] Mock<IMediator> mediator,
+        [Greedy] LegalEntitiesController controller,
+        CancellationToken token)
+        {
+            // Arrange
+            var pagedResult = new PaginatedList<AccountLegalEntity>(mockResponse.LegalEntities.Items.ToList(), 1, pageNumber, pageSize);
+            mockResponse.LegalEntities = pagedResult;
+
+            mediator.Setup(p => p.Send(It.Is<GetAllAccountLegalEntitiesByHashedAccountIdQuery>(q =>
+                    q.AccountId == accountId &&
+                    q.PageNumber == pageNumber && q.PageSize == pageSize && q.SortColumn == sortColumn && q.IsAscending == isAscending), It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(mockResponse);
+
+            // Act
+            var result = await controller.GetAllLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending, token);
+
+            // Assert
+            result.Should().BeOfType<Ok<GetAllAccountLegalEntitiesResponse>>();
+            var okResult = result as Ok<GetAllAccountLegalEntitiesResponse>;
+
+            okResult!.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            okResult.Value!.LegalEntities.Count().Should().Be(mockResponse.LegalEntities.Items.Count);
+            okResult.Value!.PageInfo.PageSize.Should().Be(pageSize);
+            okResult.Value!.PageInfo.PageIndex.Should().Be(pageNumber);
+        }
+
+        [Test, RecursiveMoqAutoData]
+        public async Task GetAllByAccountId_Returns_Empty_WhenNoEntitiesExist(
+            long accountId,
+            int pageNumber,
+            int pageSize,
+            string sortColumn,
+            bool isAscending,
+            GetAllAccountLegalEntitiesByHashedAccountIdQueryResult mockResponse,
+            [Frozen] Mock<IMediator> mediator,
+            [Greedy] LegalEntitiesController controller,
+            CancellationToken token)
+        {
+            // Arrange
+            var pagedResult = new PaginatedList<AccountLegalEntity>([], 0, pageNumber, pageSize);
+            mockResponse.LegalEntities = pagedResult;
+
+            mediator.Setup(p => p.Send(It.Is<GetAllAccountLegalEntitiesByHashedAccountIdQuery>(q =>
+                    q.AccountId == accountId &&
+                    q.PageNumber == pageNumber && q.PageSize == pageSize && q.SortColumn == sortColumn && q.IsAscending == isAscending), It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(mockResponse);
+
+            // Act
+            var result = await controller.GetAllLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending, token);
+
+            // Assert
+            result.Should().BeOfType<Ok<GetAllAccountLegalEntitiesResponse>>();
+            var okResult = result as Ok<GetAllAccountLegalEntitiesResponse>;
+
+            okResult!.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            okResult.Value!.LegalEntities.Count().Should().Be(0);
+            okResult.Value!.PageInfo.PageSize.Should().Be(pageSize);
+            okResult.Value!.PageInfo.PageIndex.Should().Be(pageNumber);
+        }
+
+        [Test, RecursiveMoqAutoData]
+        public async Task GetAllByAccountId_Returns_Exception_WhenInvalidAccountId(
+            long accountId,
+            int pageNumber,
+            int pageSize,
+            string sortColumn,
+            bool isAscending,
+            [Frozen] Mock<IMediator> mediator,
+            [Greedy] LegalEntitiesController controller,
+            CancellationToken token)
+        {
+            // Arrange
+            mediator.Setup(p => p.Send(It.Is<GetAllAccountLegalEntitiesByHashedAccountIdQuery>(q =>
+                        q.AccountId == accountId &&
+                        q.PageNumber == pageNumber &&
+                        q.PageSize == pageSize &&
+                        q.SortColumn == sortColumn &&
+                        q.IsAscending == isAscending),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception());
+
+            // Act
+            var result = await controller.GetAllLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending, token);
+
+            // Assert
+            result.Should().BeOfType<ProblemHttpResult>();
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerAccounts.Api/Controllers/LegalEntitiesController.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api/Controllers/LegalEntitiesController.cs
@@ -1,29 +1,31 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.EmployerAccounts.Api.Authorization;
+using SFA.DAS.EmployerAccounts.Api.Extensions;
 using SFA.DAS.EmployerAccounts.Api.Mappings;
+using SFA.DAS.EmployerAccounts.Api.Responses;
 using SFA.DAS.EmployerAccounts.Api.Types;
 using SFA.DAS.EmployerAccounts.Exceptions;
 using SFA.DAS.EmployerAccounts.Queries.GetAccountLegalEntitiesByHashedAccountId;
+using SFA.DAS.EmployerAccounts.Queries.GetAllAccountLegalEntitiesByHashedAccountId;
 using SFA.DAS.EmployerAccounts.Queries.GetLegalEntity;
 
 namespace SFA.DAS.EmployerAccounts.Api.Controllers;
 
 [Route("api/accounts/{accountId}/legalentities")]
 [Authorize(Policy = ApiRoles.ReadAllEmployerAccountBalances)]
-public class LegalEntitiesController : ControllerBase
+public class LegalEntitiesController(IMediator mediator, ILogger<LegalEntitiesController> logger) : ControllerBase
 {
-    private readonly IMediator _mediator;
-
-    public LegalEntitiesController(IMediator mediator)
-    {
-        _mediator = mediator;
-    }
-    
     [Route("", Name = "GetLegalEntities")]
     [HttpGet]
     public async Task<IActionResult> GetLegalEntities(long accountId, bool includeDetails = false)
@@ -32,7 +34,7 @@ public class LegalEntitiesController : ControllerBase
 
         try
         {
-            result = await _mediator.Send(
+            result = await mediator.Send(
                 new GetAccountLegalEntitiesByHashedAccountIdRequest
                 {
                     AccountId = accountId
@@ -74,11 +76,41 @@ public class LegalEntitiesController : ControllerBase
         return Ok(model);
     }
 
+    [Route("GetAll", Name = "GetAllLegalEntities")]
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(GetAllAccountLegalEntitiesResponse), StatusCodes.Status200OK)]
+    public async Task<IResult> GetAllLegalEntities(
+        [FromRoute, Required] long accountId,
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 10,
+        [FromQuery] string sortColumn = nameof(AccountLegalEntity.Name),
+        [FromQuery] bool isAscending = false,
+        CancellationToken token = default)
+    {
+        try
+        {
+            var response = await mediator.Send(new GetAllAccountLegalEntitiesByHashedAccountIdQuery(accountId, pageNumber, pageSize, sortColumn, isAscending), token);
+
+            var model = response.LegalEntities
+                .Items
+                .Select(entity => LegalEntityMapping.MapFromAccountLegalEntity(entity, null, false));
+
+            return TypedResults.Ok(new GetAllAccountLegalEntitiesResponse(response.LegalEntities.ToPageInfo(), model));
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Unable to Get all legal entities by account Id : An error occurred");
+            return Results.Problem(statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
     [HttpGet]
     [Route("{legalEntityId}", Name = "GetLegalEntity")]
     public async Task<IActionResult> GetLegalEntity(long accountId, long legalEntityId, bool includeAllAgreements = false)
     {
-        var response = await _mediator.Send(request: new GetLegalEntityQuery(accountId, legalEntityId));
+        var response = await mediator.Send(request: new GetLegalEntityQuery(accountId, legalEntityId));
 
         var model = LegalEntityMapping.MapFromAccountLegalEntity(response.LegalEntity, response.LatestAgreement,
             includeAllAgreements);

--- a/src/SFA.DAS.EmployerAccounts.Api/Extensions/PageInfoExtensions.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api/Extensions/PageInfoExtensions.cs
@@ -1,0 +1,18 @@
+﻿using SFA.DAS.EmployerAccounts.Api.Responses;
+using SFA.DAS.EmployerAccounts.Models;
+using SFA.DAS.EmployerAccounts.Models.Account;
+
+namespace SFA.DAS.EmployerAccounts.Api.Extensions
+{
+    public static class PageInfoExtensions
+    {
+        public static PageInfo ToPageInfo(this PaginatedList<AccountLegalEntity> paginatedList)
+            =>
+                new(paginatedList.TotalCount,
+                    paginatedList.PageIndex,
+                    paginatedList.PageSize,
+                    paginatedList.TotalPages,
+                    paginatedList.HasPreviousPage,
+                    paginatedList.HasNextPage);
+    }
+}

--- a/src/SFA.DAS.EmployerAccounts.Api/Responses/GetAllAccountLegalEntitiesResponse.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api/Responses/GetAllAccountLegalEntitiesResponse.cs
@@ -1,0 +1,7 @@
+﻿using System.Collections.Generic;
+using LegalEntity = SFA.DAS.EmployerAccounts.Api.Types.LegalEntity;
+
+namespace SFA.DAS.EmployerAccounts.Api.Responses
+{
+    public record GetAllAccountLegalEntitiesResponse(PageInfo PageInfo, IEnumerable<LegalEntity> LegalEntities);
+}

--- a/src/SFA.DAS.EmployerAccounts.Api/Responses/PageInfo.cs
+++ b/src/SFA.DAS.EmployerAccounts.Api/Responses/PageInfo.cs
@@ -1,0 +1,4 @@
+﻿namespace SFA.DAS.EmployerAccounts.Api.Responses
+{
+    public record struct PageInfo(int TotalCount, int PageIndex, int PageSize, int TotalPages, bool HasPreviousPage, bool HasNextPage);
+}

--- a/src/SFA.DAS.EmployerAccounts.Api/SFA.DAS.EmployerAccounts.Api.csproj
+++ b/src/SFA.DAS.EmployerAccounts.Api/SFA.DAS.EmployerAccounts.Api.csproj
@@ -8,31 +8,31 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
-        <PackageReference Include="AutoMapper" Version="13.0.1"/>
-        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2"/>
-        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0"/>
-        <PackageReference Include="Microsoft.Extensions.HealthChecks.SqlServer" Version="1.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+        <PackageReference Include="AutoMapper" Version="13.0.1" />
+        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+        <PackageReference Include="Microsoft.Extensions.HealthChecks.SqlServer" Version="1.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="SFA.DAS.Api.Common" Version="17.1.135" />
-        <PackageReference Include="SFA.DAS.Common.Domain" Version="1.4.283"/>
-        <PackageReference Include="SFA.DAS.Encoding" Version="1.1.76"/>
-        <PackageReference Include="SFA.DAS.NServiceBus.SqlServer" Version="16.0.20"/>
-        <PackageReference Include="SFA.DAS.UnitOfWork.EntityFrameworkCore" Version="9.0.28"/>
-        <PackageReference Include="SFA.DAS.UnitOfWork.Mvc" Version="9.0.28"/>
-        <PackageReference Include="SFA.DAS.UnitOfWork.NServiceBus" Version="9.0.28"/>
-        <PackageReference Include="SFA.DAS.Validation.Mvc" Version="6.0.30"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3"/>
+        <PackageReference Include="SFA.DAS.Common.Domain" Version="1.4.283" />
+        <PackageReference Include="SFA.DAS.Encoding" Version="1.1.76" />
+        <PackageReference Include="SFA.DAS.NServiceBus.SqlServer" Version="16.0.20" />
+        <PackageReference Include="SFA.DAS.UnitOfWork.EntityFrameworkCore" Version="9.0.28" />
+        <PackageReference Include="SFA.DAS.UnitOfWork.Mvc" Version="9.0.28" />
+        <PackageReference Include="SFA.DAS.UnitOfWork.NServiceBus" Version="9.0.28" />
+        <PackageReference Include="SFA.DAS.Validation.Mvc" Version="6.0.30" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
         <PackageReference Include="System.Net.Http" Version="4.3.4">
         </PackageReference>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\SFA.DAS.EmployerAccounts.Api.Client\SFA.DAS.EmployerAccounts.Api.Client.csproj"/>
-        <ProjectReference Include="..\SFA.DAS.EmployerAccounts.Api.Types\SFA.DAS.EmployerAccounts.Api.Types.csproj"/>
-        <ProjectReference Include="..\SFA.DAS.EmployerAccounts.ReadStore\SFA.DAS.EmployerAccounts.ReadStore\SFA.DAS.EmployerAccounts.ReadStore.csproj"/>
-        <ProjectReference Include="..\SFA.DAS.EmployerAccounts.Types\SFA.DAS.EmployerAccounts.Types.csproj"/>
-        <ProjectReference Include="..\SFA.DAS.EmployerAccounts\SFA.DAS.EmployerAccounts.csproj"/>
+        <ProjectReference Include="..\SFA.DAS.EmployerAccounts.Api.Client\SFA.DAS.EmployerAccounts.Api.Client.csproj" />
+        <ProjectReference Include="..\SFA.DAS.EmployerAccounts.Api.Types\SFA.DAS.EmployerAccounts.Api.Types.csproj" />
+        <ProjectReference Include="..\SFA.DAS.EmployerAccounts.ReadStore\SFA.DAS.EmployerAccounts.ReadStore\SFA.DAS.EmployerAccounts.ReadStore.csproj" />
+        <ProjectReference Include="..\SFA.DAS.EmployerAccounts.Types\SFA.DAS.EmployerAccounts.Types.csproj" />
+        <ProjectReference Include="..\SFA.DAS.EmployerAccounts\SFA.DAS.EmployerAccounts.csproj" />
     </ItemGroup>
     <PropertyGroup>
         <WebProjectOutputDir Condition="$(WebProjectOutputDir) == '' AND $(OS) == 'Unix' ">./</WebProjectOutputDir>

--- a/src/SFA.DAS.EmployerAccounts.UnitTests/Queries/GetAllAccountLegalEntitiesByHashedAccountId/WhenHandlingGetAllAccountLegalEntitiesByHashedAccountIdQuery.cs
+++ b/src/SFA.DAS.EmployerAccounts.UnitTests/Queries/GetAllAccountLegalEntitiesByHashedAccountId/WhenHandlingGetAllAccountLegalEntitiesByHashedAccountIdQuery.cs
@@ -1,0 +1,76 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EmployerAccounts.Data.Contracts;
+using SFA.DAS.EmployerAccounts.Models;
+using SFA.DAS.EmployerAccounts.Models.Account;
+using SFA.DAS.EmployerAccounts.Queries.GetAllAccountLegalEntitiesByHashedAccountId;
+using SFA.DAS.Testing.AutoFixture;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.EmployerAccounts.UnitTests.Queries.GetAllAccountLegalEntitiesByHashedAccountId
+{
+    [TestFixture]
+    public class WhenHandlingGetAllAccountLegalEntitiesByHashedAccountIdQuery
+    {
+        [Test, RecursiveMoqAutoData]
+        public async Task GetAllAccountLegalEntitiesByHashedAccountId_ShouldReturnPaginatedList_WhenCalledWithValidParameters(
+            long accountId,
+            int pageNumber,
+            int pageSize,
+            string sortColumn,
+            bool isAscending,
+            CancellationToken token,
+            List<AccountLegalEntity> entities,
+            [Frozen] Mock<IAccountLegalEntityRepository> repositoryMock,
+            [Greedy] GetAllAccountLegalEntitiesByHashedAccountIdQueryHandler handler)
+        {
+            // Arrange
+            sortColumn = "Name";
+            isAscending = false;
+
+            var expectedList = new PaginatedList<AccountLegalEntity>(entities, 10, pageNumber, pageSize);
+            repositoryMock.Setup(repo => repo.GetAccountLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending, token))
+                .ReturnsAsync(expectedList);
+
+            // Act
+            var result = await handler.Handle(new GetAllAccountLegalEntitiesByHashedAccountIdQuery(accountId, pageNumber, pageSize, sortColumn, isAscending), token);
+
+            // Assert
+            result.LegalEntities.PageIndex.Should().Be(pageNumber);
+            result.LegalEntities.PageSize.Should().Be(pageSize);
+            result.LegalEntities.TotalCount.Should().Be(10);
+            result.LegalEntities.Items.Should().BeEquivalentTo(entities);
+            repositoryMock.Verify(repo => repo.GetAccountLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending, token), Times.Once);
+        }
+
+        [Test, RecursiveMoqAutoData]
+        public void GetAllAccountLegalEntitiesByHashedAccountId_ShouldThrowException_WhenRepositoryThrowsException(
+            long accountId,
+            int pageNumber,
+            int pageSize,
+            string sortColumn,
+            bool isAscending,
+            CancellationToken token,
+            List<AccountLegalEntity> entities,
+            [Frozen] Mock<IAccountLegalEntityRepository> repositoryMock,
+            [Greedy] GetAllAccountLegalEntitiesByHashedAccountIdQueryHandler handler)
+        {
+            // Arrange
+            sortColumn = "Name";
+            isAscending = false;
+
+            repositoryMock.Setup(repo => repo.GetAccountLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending, token))
+                .ThrowsAsync(new Exception("Repository exception"));
+
+            // Act & Assert
+            Assert.ThrowsAsync<Exception>(() => handler.Handle(new GetAllAccountLegalEntitiesByHashedAccountIdQuery(accountId, pageNumber, pageSize, sortColumn, isAscending), token));
+
+            repositoryMock.Verify(repo => repo.GetAccountLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending, token), Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerAccounts/Data/AccountLegalEntityRepository.cs
+++ b/src/SFA.DAS.EmployerAccounts/Data/AccountLegalEntityRepository.cs
@@ -1,21 +1,17 @@
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using SFA.DAS.EmployerAccounts.Data.Contracts;
+using SFA.DAS.EmployerAccounts.Extensions;
+using SFA.DAS.EmployerAccounts.Models;
 using SFA.DAS.EmployerAccounts.Models.Account;
 
 namespace SFA.DAS.EmployerAccounts.Data;
 
-public class AccountLegalEntityRepository :  IAccountLegalEntityRepository
+public class AccountLegalEntityRepository(Lazy<EmployerAccountsDbContext> db) : IAccountLegalEntityRepository
 {
-    private readonly Lazy<EmployerAccountsDbContext> _db;
-
-    public AccountLegalEntityRepository(Lazy<EmployerAccountsDbContext> db)
-    {
-        _db = db;
-    }
-
     public async Task<List<AccountLegalEntity>> GetAccountLegalEntities(long accountId)
     {
-        var accountLegalEntities = await _db.Value.AccountLegalEntities
+        var accountLegalEntities = await db.Value.AccountLegalEntities
             .Include(x => x.LegalEntity)
             .Include(x => x.Agreements)
             .Where(l =>
@@ -24,5 +20,28 @@ public class AccountLegalEntityRepository :  IAccountLegalEntityRepository
                  l.Deleted == null).ToListAsync();
 
         return accountLegalEntities;
+    }
+
+    public async Task<PaginatedList<AccountLegalEntity>> GetAccountLegalEntities(
+        long accountId,
+        int pageNumber,
+        int pageSize,
+        string sortColumn,
+        bool isAscending,
+        CancellationToken token)
+    {
+        var query = db.Value.AccountLegalEntities
+            .AsNoTracking()
+            .Include(x => x.LegalEntity)
+            .Include(x => x.Agreements)
+            .Where(l =>
+                l.Account.Id == accountId &&
+                (l.PendingAgreementId != null || l.SignedAgreementId != null) &&
+                l.Deleted == null);
+
+        // Defensive: Ensure sortColumn is not null or empty, fallback to Name
+        var safeSortColumn = string.IsNullOrWhiteSpace(sortColumn) ? nameof(AccountLegalEntity.Name) : sortColumn;
+
+        return await query.GetPagedAsync(pageNumber, pageSize, safeSortColumn, isAscending, token);
     }
 }

--- a/src/SFA.DAS.EmployerAccounts/Data/Contracts/IAccountLegalEntityRepository.cs
+++ b/src/SFA.DAS.EmployerAccounts/Data/Contracts/IAccountLegalEntityRepository.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using SFA.DAS.EmployerAccounts.Models;
 using SFA.DAS.EmployerAccounts.Models.Account;
 
 namespace SFA.DAS.EmployerAccounts.Data.Contracts;
@@ -5,4 +7,5 @@ namespace SFA.DAS.EmployerAccounts.Data.Contracts;
 public interface IAccountLegalEntityRepository
 {
     Task<List<AccountLegalEntity>> GetAccountLegalEntities(long accountId);
+    Task<PaginatedList<AccountLegalEntity>> GetAccountLegalEntities(long accountId, int pageNumber, int pageSize, string sortColumn, bool isAscending, CancellationToken token);
 }

--- a/src/SFA.DAS.EmployerAccounts/Extensions/QueryableExtensions.cs
+++ b/src/SFA.DAS.EmployerAccounts/Extensions/QueryableExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+using System.Threading;
+using SFA.DAS.EmployerAccounts.Models;
+
+namespace SFA.DAS.EmployerAccounts.Extensions
+{
+    public static class QueryableExtensions
+    {
+        public static async Task<PaginatedList<T>> GetPagedAsync<T>(
+            this IQueryable<T> query,
+            int pageNumber,
+            int pageSize,
+            string sortColumn,
+            bool isAscending = true,
+            CancellationToken token = default)
+        {
+            int totalRecords = await query.CountAsync(token);
+
+            if (!string.IsNullOrWhiteSpace(sortColumn))
+            {
+                var param = Expression.Parameter(typeof(T), "x");
+                var property = Expression.Property(param, sortColumn);
+                var lambda = Expression.Lambda(property, param);
+
+                string methodName = isAscending ? "OrderBy" : "OrderByDescending";
+                var orderByExpression = Expression.Call(
+                    typeof(Queryable),
+                    methodName,
+                    [typeof(T), property.Type],
+                    query.Expression,
+                    Expression.Quote(lambda)
+                );
+
+                query = query.Provider.CreateQuery<T>(orderByExpression);
+            }
+
+            var items = await query
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(token);
+
+            return new PaginatedList<T>(items, totalRecords, pageNumber, pageSize);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerAccounts/Models/PaginatedList.cs
+++ b/src/SFA.DAS.EmployerAccounts/Models/PaginatedList.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace SFA.DAS.EmployerAccounts.Models
+{
+    public class PaginatedList<T>(List<T> items, int count, int pageIndex, int pageSize)
+    {
+        public List<T> Items { get; private set; } = items;
+        public int TotalCount { get; private set; } = count;
+        public int PageIndex { get; private set; } = pageIndex;
+        public int PageSize { get; private set; } = pageSize;
+        public int TotalPages => (int)Math.Ceiling(TotalCount / (double)PageSize);
+
+        public bool HasPreviousPage => PageIndex > 1;
+        public bool HasNextPage => PageIndex < TotalPages;
+
+        public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> source, int total, int pageIndex, int pageSize)
+        {
+            var items = await source.ToListAsync();
+            return new PaginatedList<T>(items, total, pageIndex, pageSize);
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerAccounts/Queries/GetAllAccountLegalEntitiesByHashedAccountId/GetAllAccountLegalEntitiesByHashedAccountIdQuery.cs
+++ b/src/SFA.DAS.EmployerAccounts/Queries/GetAllAccountLegalEntitiesByHashedAccountId/GetAllAccountLegalEntitiesByHashedAccountIdQuery.cs
@@ -1,0 +1,10 @@
+﻿namespace SFA.DAS.EmployerAccounts.Queries.GetAllAccountLegalEntitiesByHashedAccountId
+{
+    public sealed record GetAllAccountLegalEntitiesByHashedAccountIdQuery(
+        long AccountId,
+        int PageNumber,
+        int PageSize,
+        string SortColumn,
+        bool IsAscending)
+        : IRequest<GetAllAccountLegalEntitiesByHashedAccountIdQueryResult>;
+}

--- a/src/SFA.DAS.EmployerAccounts/Queries/GetAllAccountLegalEntitiesByHashedAccountId/GetAllAccountLegalEntitiesByHashedAccountIdQueryHandler.cs
+++ b/src/SFA.DAS.EmployerAccounts/Queries/GetAllAccountLegalEntitiesByHashedAccountId/GetAllAccountLegalEntitiesByHashedAccountIdQueryHandler.cs
@@ -1,0 +1,24 @@
+﻿using SFA.DAS.EmployerAccounts.Data.Contracts;
+using System.Threading;
+
+namespace SFA.DAS.EmployerAccounts.Queries.GetAllAccountLegalEntitiesByHashedAccountId
+{
+    public class GetAllAccountLegalEntitiesByHashedAccountIdQueryHandler(IAccountLegalEntityRepository accountLegalEntityRepository): IRequestHandler<GetAllAccountLegalEntitiesByHashedAccountIdQuery, GetAllAccountLegalEntitiesByHashedAccountIdQueryResult>
+    {
+        public async Task<GetAllAccountLegalEntitiesByHashedAccountIdQueryResult> Handle(GetAllAccountLegalEntitiesByHashedAccountIdQuery request, CancellationToken cancellationToken)
+        {
+            var accountLegalEntities = await accountLegalEntityRepository.GetAccountLegalEntities(
+                request.AccountId,
+                request.PageNumber,
+                request.PageSize,
+                request.SortColumn,
+                request.IsAscending,
+                cancellationToken);
+
+            return new GetAllAccountLegalEntitiesByHashedAccountIdQueryResult
+            {
+                LegalEntities = accountLegalEntities
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerAccounts/Queries/GetAllAccountLegalEntitiesByHashedAccountId/GetAllAccountLegalEntitiesByHashedAccountIdQueryResult.cs
+++ b/src/SFA.DAS.EmployerAccounts/Queries/GetAllAccountLegalEntitiesByHashedAccountId/GetAllAccountLegalEntitiesByHashedAccountIdQueryResult.cs
@@ -1,0 +1,10 @@
+﻿using SFA.DAS.EmployerAccounts.Models;
+using SFA.DAS.EmployerAccounts.Models.Account;
+
+namespace SFA.DAS.EmployerAccounts.Queries.GetAllAccountLegalEntitiesByHashedAccountId
+{
+    public record GetAllAccountLegalEntitiesByHashedAccountIdQueryResult
+    {
+        public PaginatedList<AccountLegalEntity> LegalEntities { get; set; }
+    }
+}


### PR DESCRIPTION
✨ Add pagination to LegalEntitiesController

- Introduced `GetAllLegalEntities` endpoint for paginated retrieval.
- Updated `AccountLegalEntityRepository` for pagination and sorting.
- Created new classes: `GetAllAccountLegalEntitiesResponse`, `PageInfo`, and `PaginatedList<T>`.
- Added unit tests for new functionality and error handling.
- Updated project file for proper references and formatting.

Changes made by Balaji Jambulingam